### PR TITLE
Fix benchmark output showing max instead of min

### DIFF
--- a/tiny-bench/src/output/mod.rs
+++ b/tiny-bench/src/output/mod.rs
@@ -86,7 +86,7 @@ impl Output for SimpleStdout {
     ) {
         let analysis = simple_analyze_sampling_data(sampling_data);
         print_sample_header(label, total_iters, analysis.elapsed, cfg.num_samples as u64);
-        print_elapsed(analysis.max, analysis.average, analysis.max);
+        print_elapsed(analysis.min, analysis.average, analysis.max);
     }
 }
 
@@ -141,7 +141,7 @@ impl Output for ComparedStdout {
     ) {
         let analysis = simple_analyze_sampling_data(sampling_data);
         print_sample_header(label, total_iters, analysis.elapsed, cfg.num_samples as u64);
-        print_elapsed(analysis.max, analysis.average, analysis.max);
+        print_elapsed(analysis.min, analysis.average, analysis.max);
         match disk::try_read_last_simpling(label) {
             Ok(Some(last)) => {
                 let old_analysis = simple_analyze_sampling_data(&last);


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR fixes the output of e.g. a `tiny_bench::bench_labeled` benchmark: it currently doesn't print the min time, the max is printed instead.

For example:

```console
Lhash L26 warming up for 3.00s
Lhash L26 mean warm up execution time 626.35µs running 10.1 thousand iterations
Lhash L26 [10.1 thousand iterations in 6.36s with 100.0 samples]:
        elapsed [min mean max]: [668.02µs 630.14µs 668.02µs]
```
