### PR TITLE
Prepare for 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
-## [0.1.0] - TBD
+## [0.1.1] - 2022-08-19
+### Fixed
+- Fix results display showing max instead of min; thanks @lqd!
+
+## [0.1.0] - 2022-06-10
 ### Added
 - A tiny benchmarker
 - A tiny timer

--- a/tiny-bench/Cargo.toml
+++ b/tiny-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-bench"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Embark <opensource@embark-studios.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Just wanted to release a new version including the patch from https://github.com/EmbarkStudios/tiny-bench/pull/1.

I've also marked the git commit that was used for the 0.1.0 release on crates.io as the 0.1.0 git tag, and pushed that already, fwiw.