### PR TITLE
ci: Fix publish check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,4 @@ jobs:
           override: true
       - run: cargo fetch
       - name: cargo publish check
-        run: cargo publish --dry-run
+        run: cargo publish --dry-run -p tiny-bench


### PR DESCRIPTION
Since this is a workspace, the publish command requires that the package to be published be specified on the command line. This should fix the CI pipeline on `main`.