### PR TITLE
gate the benchmark behind the bench feature that it uses

### DIFF
--- a/tiny-bench/benches/benchmark.rs
+++ b/tiny-bench/benches/benchmark.rs
@@ -1,13 +1,19 @@
 use std::time::Duration;
+#[cfg(bench)]
 use tiny_bench::{black_box, BenchmarkConfig};
 
 fn main() {
+    #[cfg(bench)]
     bench_test_one();
+    #[cfg(bench)]
     bench_test_two();
+    #[cfg(bench)]
     bench_test_three();
+    #[cfg(bench)]
     bench_test_four();
 }
 
+#[cfg(bench)]
 fn bench_test_one() {
     tiny_bench::bench_labeled("test one", || {
         let mut v: Vec<i32> = Vec::with_capacity(10_000);
@@ -22,6 +28,7 @@ fn bench_test_one() {
     });
 }
 
+#[cfg(bench)]
 fn bench_test_two() {
     tiny_bench::bench_with_setup_labeled(
         "test two",
@@ -43,10 +50,12 @@ fn bench_test_two() {
     );
 }
 
+#[cfg(bench)]
 fn bench_test_three() {
     tiny_bench::bench_labeled("test three, empty", || {});
 }
 
+#[cfg(bench)]
 fn bench_test_four() {
     tiny_bench::bench_with_configuration_labeled(
         "test four, max_it",


### PR DESCRIPTION
### Checklist

* [ x ] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [ x ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [ x ] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

So that 'cargo bench --no-default-features' doesn't have compilation errors. This is due to that Debian's build system runs the test/benches for all features, each individual feature and no features.

### Related Issues

n/a